### PR TITLE
v1.2.9r1 - Advanced Cache Manager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>tk.mihou</groupId>
     <artifactId>Amatsuki</artifactId>
-    <version>1.2.8r1</version>
+    <version>1.2.9r1</version>
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/tk/mihou/amatsuki/api/Amatsuki.java
+++ b/src/main/java/tk/mihou/amatsuki/api/Amatsuki.java
@@ -1,6 +1,7 @@
 package tk.mihou.amatsuki.api;
 
 import tk.mihou.amatsuki.api.connection.AmatsukiConnector;
+import tk.mihou.amatsuki.api.enums.AmatsukiNames;
 import tk.mihou.amatsuki.api.enums.OrderBy;
 import tk.mihou.amatsuki.api.enums.Rankings;
 import tk.mihou.amatsuki.entities.ForumThread;
@@ -10,7 +11,9 @@ import tk.mihou.amatsuki.entities.story.lower.StoryResults;
 import tk.mihou.amatsuki.entities.user.User;
 import tk.mihou.amatsuki.entities.user.lower.UserResults;
 import tk.mihou.amatsuki.impl.cache.CacheManager;
+import tk.mihou.amatsuki.impl.cache.enums.CacheTypes;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -31,6 +34,17 @@ public class Amatsuki {
     }
 
     /**
+     * Sets the referrer, default: https://manabot.fun/hello.html
+     * we will only set the referrer for story pages because of the new referrer statistic.
+     * @param referrer the referrer to use.
+     * @return Amatsuki instance for chain calling.
+     */
+    public Amatsuki setReferrer(String referrer){
+        connector.setReferrer(referrer);
+        return this;
+    }
+
+    /**
      * Sets the status of the CacheManager whether to enable
      * or to disable the CacheManager (recommended enabled since
      * it is only for stories and users, excluding search).
@@ -43,6 +57,38 @@ public class Amatsuki {
      */
     public Amatsuki setCache(boolean enabled){
         CacheManager.switchStatus(enabled);
+        return this;
+    }
+
+    /**
+     * Do you want to enable certain cache types?
+     * by default, all cache types are enabled so doing this
+     * will not change anything unless you disable some.
+     *
+     * By default, the CacheManager is already enabled to reduce
+     * the load on ScribbleHub's side.
+     *
+     * @param cacheTypes do you want to enable a certain cache that is disabled?
+     * @return Amatsuki.
+     */
+    public Amatsuki enableCache(CacheTypes... cacheTypes){
+        CacheManager.enable(cacheTypes);
+        return this;
+    }
+
+    /**
+     * Do you want to disable certain cache types?
+     * by default, all cache types are enabled so doing this
+     * will disable a certain cache type.
+     *
+     * By default, the CacheManager is already enabled to reduce
+     * the load on ScribbleHub's side.
+     *
+     * @param cacheTypes do you want to disable a certain cache that is enabled?
+     * @return Amatsuki.
+     */
+    public Amatsuki disableCache(CacheTypes... cacheTypes){
+        CacheManager.disable(cacheTypes);
         return this;
     }
 
@@ -70,6 +116,15 @@ public class Amatsuki {
      * @return User.
      */
     public CompletableFuture<List<UserResults>> searchUser(String query) {
+        if(CacheManager.search.get()){
+            if(CacheManager.isCached(String.format(AmatsukiNames.USER_SEARCH.getFormat(), query))){
+                List<UserResults> result = (List<UserResults>) CacheManager.getList(String.format(AmatsukiNames.USER_SEARCH.getFormat(), query));
+                if(result != null) {
+                    return CompletableFuture.supplyAsync(() -> result);
+                }
+            }
+        }
+
         return connector.searchUser(query, defTimeout);
     }
 
@@ -96,6 +151,15 @@ public class Amatsuki {
      * @return Story.
      */
     public CompletableFuture<List<StoryResults>> searchStory(String query) {
+        if(CacheManager.search.get()){
+            if(CacheManager.isCached(String.format(AmatsukiNames.STORY_SEARCH.getFormat(), query))){
+                List<StoryResults> result = (List<StoryResults>) CacheManager.getList(String.format(AmatsukiNames.STORY_SEARCH.getFormat(), query));
+                if(result != null) {
+                    return CompletableFuture.supplyAsync(() -> result);
+                }
+            }
+        }
+
         return connector.searchStory(query, defTimeout);
     }
 
@@ -104,6 +168,15 @@ public class Amatsuki {
      * @return List of LatestUpdatesResults
      */
     public CompletableFuture<List<LatestUpdatesResult>> getLatestUpdates(){
+        if(CacheManager.rankings.get()){
+            if(CacheManager.isCached(AmatsukiNames.LATEST_UPDATES.getFormat())){
+                List<LatestUpdatesResult> result = (List<LatestUpdatesResult>) CacheManager.getList(AmatsukiNames.LATEST_UPDATES.getFormat());
+                if(result != null) {
+                    return CompletableFuture.supplyAsync(() -> result);
+                }
+            }
+        }
+
         return connector.getLatestUpdates(defTimeout);
     }
 
@@ -113,6 +186,15 @@ public class Amatsuki {
      * @return List of LatestUpdatesResults
      */
     public CompletableFuture<List<LatestUpdatesResult>> getLatestUpdates(int timeout){
+        if(CacheManager.rankings.get()){
+            if(CacheManager.isCached(AmatsukiNames.LATEST_UPDATES.getFormat())){
+                List<LatestUpdatesResult> result = (List<LatestUpdatesResult>) CacheManager.getList(AmatsukiNames.LATEST_UPDATES.getFormat());
+                if(result != null) {
+                    return CompletableFuture.supplyAsync(() -> result);
+                }
+            }
+        }
+
         return connector.getLatestUpdates(timeout);
     }
 
@@ -121,6 +203,15 @@ public class Amatsuki {
      * @return List<StoryResults>
      */
     public CompletableFuture<List<StoryResults>> getLatestSeries(){
+        if(CacheManager.rankings.get()){
+            if(CacheManager.isCached(AmatsukiNames.LATEST_SERIES.getFormat())){
+                List<StoryResults> result = (List<StoryResults>) CacheManager.getList(AmatsukiNames.LATEST_SERIES.getFormat());
+                if(result != null) {
+                    return CompletableFuture.supplyAsync(() -> result);
+                }
+            }
+        }
+
         return connector.getLatestSeries(defTimeout);
     }
 
@@ -130,6 +221,15 @@ public class Amatsuki {
      * @return List<StoryResults>
      */
     public CompletableFuture<List<StoryResults>> getLatestSeries(int timeout){
+        if(CacheManager.rankings.get()){
+            if(CacheManager.isCached(AmatsukiNames.LATEST_SERIES.getFormat())){
+                List<StoryResults> result = (List<StoryResults>) CacheManager.getList(AmatsukiNames.LATEST_SERIES.getFormat());
+                if(result != null) {
+                    return CompletableFuture.supplyAsync(() -> result);
+                }
+            }
+        }
+
         return connector.getLatestSeries(timeout);
     }
 
@@ -138,6 +238,15 @@ public class Amatsuki {
      * @return List<StoryResults>
      */
     public CompletableFuture<List<StoryResults>> getTrending(){
+        if(CacheManager.rankings.get()){
+            if(CacheManager.isCached(String.format(AmatsukiNames.RANKINGS.getFormat(), Rankings.RISING.getIdentifier(), OrderBy.DAILY.getLocation()))){
+                List<StoryResults> result = (List<StoryResults>) CacheManager.getList(String.format(AmatsukiNames.RANKINGS.getFormat(), Rankings.RISING.getIdentifier(), OrderBy.DAILY.getLocation()));
+                if(result != null) {
+                    return CompletableFuture.supplyAsync(() -> result);
+                }
+            }
+        }
+
         return connector.getRanking(Rankings.RISING, OrderBy.DAILY, defTimeout);
     }
 
@@ -147,6 +256,15 @@ public class Amatsuki {
      * @return List<StoryResults>
      */
     public CompletableFuture<List<StoryResults>> getTrending(OrderBy order){
+        if(CacheManager.rankings.get()){
+            if(CacheManager.isCached(String.format(AmatsukiNames.RANKINGS.getFormat(), Rankings.RISING.getIdentifier(), order.getLocation()))){
+                List<StoryResults> result = (List<StoryResults>) CacheManager.getList(String.format(AmatsukiNames.RANKINGS.getFormat(), Rankings.RISING.getIdentifier(), order.getLocation()));
+                if(result != null) {
+                    return CompletableFuture.supplyAsync(() -> result);
+                }
+            }
+        }
+
         return connector.getRanking(Rankings.RISING, order, defTimeout);
     }
 
@@ -158,6 +276,15 @@ public class Amatsuki {
      * @return List<StoryResults>
      */
     public CompletableFuture<List<StoryResults>> getTrending(OrderBy order, int timeout){
+        if(CacheManager.rankings.get()){
+            if(CacheManager.isCached(String.format(AmatsukiNames.RANKINGS.getFormat(), Rankings.RISING.getIdentifier(), order.getLocation()))){
+                List<StoryResults> result = (List<StoryResults>) CacheManager.getList(String.format(AmatsukiNames.RANKINGS.getFormat(), Rankings.RISING.getIdentifier(), order.getLocation()));
+                if(result != null) {
+                    return CompletableFuture.supplyAsync(() -> result);
+                }
+            }
+        }
+
         return connector.getRanking(Rankings.RISING, order, timeout);
     }
 
@@ -167,6 +294,15 @@ public class Amatsuki {
      * @return List<StoryResults>
      */
     public CompletableFuture<List<StoryResults>> getTrending(int timeout){
+        if(CacheManager.rankings.get()){
+            if(CacheManager.isCached(String.format(AmatsukiNames.RANKINGS.getFormat(), Rankings.RISING.getIdentifier(), OrderBy.DAILY.getLocation()))){
+                List<StoryResults> result = (List<StoryResults>) CacheManager.getList(String.format(AmatsukiNames.RANKINGS.getFormat(), Rankings.RISING.getIdentifier(), OrderBy.DAILY.getLocation()));
+                if(result != null) {
+                    return CompletableFuture.supplyAsync(() -> result);
+                }
+            }
+        }
+
         return connector.getRanking(Rankings.RISING, OrderBy.DAILY, timeout);
     }
 
@@ -175,6 +311,15 @@ public class Amatsuki {
      * @return List<StoryResults>
      */
     public CompletableFuture<List<StoryResults>> getCertainRankings(Rankings ranking){
+        if(CacheManager.rankings.get()){
+            if(CacheManager.isCached(String.format(AmatsukiNames.RANKINGS.getFormat(), ranking.getIdentifier(), OrderBy.DAILY.getLocation()))){
+                List<StoryResults> result = (List<StoryResults>) CacheManager.getList(String.format(AmatsukiNames.RANKINGS.getFormat(), ranking.getIdentifier(), OrderBy.DAILY.getLocation()));
+                if(result != null) {
+                    return CompletableFuture.supplyAsync(() -> result);
+                }
+            }
+        }
+
         return connector.getRanking(ranking, OrderBy.DAILY, defTimeout);
     }
 
@@ -184,6 +329,15 @@ public class Amatsuki {
      * @return List<StoryResults>
      */
     public CompletableFuture<List<StoryResults>> getCertainRankings(Rankings ranking, OrderBy order){
+        if(CacheManager.rankings.get()){
+            if(CacheManager.isCached(String.format(AmatsukiNames.RANKINGS.getFormat(), ranking.getIdentifier(), order.getLocation()))){
+                List<StoryResults> result = (List<StoryResults>) CacheManager.getList(String.format(AmatsukiNames.RANKINGS.getFormat(), ranking.getIdentifier(), order.getLocation()));
+                if(result != null) {
+                    return CompletableFuture.supplyAsync(() -> result);
+                }
+            }
+        }
+
         return connector.getRanking(ranking, order, defTimeout);
     }
 
@@ -193,6 +347,15 @@ public class Amatsuki {
      * @return List<StoryResults>
      */
     public CompletableFuture<List<StoryResults>> getCertainRankings(Rankings ranking, int timeout){
+        if(CacheManager.rankings.get()){
+            if(CacheManager.isCached(String.format(AmatsukiNames.RANKINGS.getFormat(), ranking.getIdentifier(), OrderBy.DAILY.getLocation()))){
+                List<StoryResults> result = (List<StoryResults>) CacheManager.getList(String.format(AmatsukiNames.RANKINGS.getFormat(), ranking.getIdentifier(), OrderBy.DAILY.getLocation()));
+                if(result != null) {
+                    return CompletableFuture.supplyAsync(() -> result);
+                }
+            }
+        }
+
         return connector.getRanking(ranking, OrderBy.DAILY, timeout);
     }
 
@@ -203,6 +366,15 @@ public class Amatsuki {
      * @return List<StoryResults>
      */
     public CompletableFuture<List<StoryResults>> getCertainRankings(Rankings ranking, OrderBy order, int timeout){
+        if(CacheManager.rankings.get()){
+            if(CacheManager.isCached(String.format(AmatsukiNames.RANKINGS.getFormat(), ranking.getIdentifier(), order.getLocation()))){
+                List<StoryResults> result = (List<StoryResults>) CacheManager.getList(String.format(AmatsukiNames.RANKINGS.getFormat(), ranking.getIdentifier(), order.getLocation()));
+                if(result != null) {
+                    return CompletableFuture.supplyAsync(() -> result);
+                }
+            }
+        }
+
         return connector.getRanking(ranking, order, timeout);
     }
 
@@ -249,6 +421,15 @@ public class Amatsuki {
      * @return Story.
      */
     public CompletableFuture<List<StoryResults>> searchStory(String query, int timeout) {
+        if(CacheManager.search.get()){
+            if(CacheManager.isCached(String.format(AmatsukiNames.STORY_SEARCH.getFormat(), query))){
+                List<StoryResults> result = (List<StoryResults>) CacheManager.getList(String.format(AmatsukiNames.STORY_SEARCH.getFormat(), query));
+                if(result != null) {
+                    return CompletableFuture.supplyAsync(() -> result);
+                }
+            }
+        }
+
         return connector.searchStory(query, timeout);
     }
 
@@ -259,6 +440,15 @@ public class Amatsuki {
      * @return User
      */
     public CompletableFuture<List<UserResults>> searchUser(String query, int timeout) {
+        if(CacheManager.search.get()){
+            if(CacheManager.isCached(String.format(AmatsukiNames.USER_SEARCH.getFormat(), query))){
+                List<UserResults> result = (List<UserResults>) CacheManager.getList(String.format(AmatsukiNames.USER_SEARCH.getFormat(), query));
+                if(result != null) {
+                    return CompletableFuture.supplyAsync(() -> result);
+                }
+            }
+        }
+
         return connector.searchUser(query, timeout);
     }
 

--- a/src/main/java/tk/mihou/amatsuki/api/enums/AmatsukiNames.java
+++ b/src/main/java/tk/mihou/amatsuki/api/enums/AmatsukiNames.java
@@ -1,0 +1,18 @@
+package tk.mihou.amatsuki.api.enums;
+
+public enum AmatsukiNames {
+
+    LATEST_SERIES("LATEST-SERIES-1"), LATEST_UPDATES("LATEST-UPDATES-1"), STORY_SEARCH("%s-AMATSUKI-SEARCH-STORY"), USER_SEARCH("%s-AMATSUKI-SEARCH-USER"),
+    RANKINGS("%s-%d"), SERIES_FINDER("SERIES-FINDER-%s");
+
+    public String format;
+
+    AmatsukiNames(String format){
+        this.format = format;
+    }
+
+    public String getFormat(){
+        return format;
+    }
+
+}

--- a/src/main/java/tk/mihou/amatsuki/api/enums/Rankings.java
+++ b/src/main/java/tk/mihou/amatsuki/api/enums/Rankings.java
@@ -2,16 +2,23 @@ package tk.mihou.amatsuki.api.enums;
 
 public enum Rankings {
 
-    RISING(5), READERS(4), POPULARITY(1), FAVORITES(2), ACTIVITY(3);
+    RISING(5, "RISING-AMATSUKI"), READERS(4, "READERS-AMATSUKI"),
+    POPULARITY(1, "POPULARITY-AMATSUKI"), FAVORITES(2, "FAVORITES-AMATSUKI"), ACTIVITY(3, "ACTIVITY-AMATSUKI");
 
-    private int location;
+    private final int location;
+    private final String identifier;
 
-    Rankings(int location){
+    Rankings(int location, String identifier){
         this.location = location;
+        this.identifier = identifier;
     }
 
     public int getLocation(){
         return location;
+    }
+
+    public String getIdentifier(){
+        return identifier;
     }
 
 }

--- a/src/main/java/tk/mihou/amatsuki/impl/cache/CacheManager.java
+++ b/src/main/java/tk/mihou/amatsuki/impl/cache/CacheManager.java
@@ -1,9 +1,9 @@
 package tk.mihou.amatsuki.impl.cache;
 
 import tk.mihou.amatsuki.impl.cache.entities.CacheEntity;
+import tk.mihou.amatsuki.impl.cache.enums.CacheTypes;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -20,17 +20,30 @@ public class CacheManager {
 
     // The lifespan of the objects.
     public static AtomicInteger lifespan = new AtomicInteger(1);
+    public static AtomicInteger ranking = new AtomicInteger(6);
 
-    // The status of the CacheManager.
+    // The status of the CacheManager (DEFAULT)
     public static AtomicBoolean enabled = new AtomicBoolean(true);
+    public static AtomicBoolean search = new AtomicBoolean(true);
+    public static AtomicBoolean rankings = new AtomicBoolean(true);
 
     static final Map<String, CacheEntity> genericCache = new HashMap<>();
 
     public static <T> T getCache(Class expected, String key){
         if(genericCache.containsKey(key)){
             if(genericCache.get(key).sameType(expected)){
-                System.out.println("We are now returning the value from cache.");
                 return (T) genericCache.get(key).get();
+            }
+        }
+
+        // We can't use optionals, so we use nulls instead.
+        return null;
+    }
+
+    public static List<?> getList(String key){
+        if(genericCache.containsKey(key)){
+            if(genericCache.get(key).isList()){
+                return (List<?>) genericCache.get(key).getList();
             }
         }
 
@@ -47,6 +60,10 @@ public class CacheManager {
         return entity;
     }
 
+    public static void addCache(List<?> entity, String key, CacheTypes type){
+        genericCache.put(key, new CacheEntity<>(entity, key, type.equals(CacheTypes.RANKINGS) ? ranking.get() : lifespan.get()));
+    }
+
     public static <T> T replace(T entity, String key){
         if(genericCache.containsKey(key)){
             genericCache.get(key).replace(entity);
@@ -57,6 +74,14 @@ public class CacheManager {
         return entity;
     }
 
+    public static void replace(Collection<?> entity, String key){
+        if(genericCache.containsKey(key)){
+            genericCache.get(key).replace(entity);
+        } else {
+            genericCache.put(key, new CacheEntity<>(entity, key));
+        }
+    }
+
     public static void invalidate(String key){
         genericCache.remove(key);
     }
@@ -65,12 +90,46 @@ public class CacheManager {
         lifespan.set(span); unit = time;
     }
 
-    public static void switchStatus(){
-        enabled.set(!enabled.get());
+    /**
+     * Sets the lifespan of all other lists like rankings and search finder.
+     * @param span the amount of time to cache, to set the timeunit, please use setLifespan(...)
+     */
+    public static void setRankings(int span){
+        ranking.set(span);
     }
 
     public static void switchStatus(boolean enable){
-        enabled.set(enable);
+        if(enable){
+            enable(CacheTypes.DEFAULT, CacheTypes.RANKINGS, CacheTypes.SEARCH);
+        } else {
+            disable(CacheTypes.DEFAULT, CacheTypes.RANKINGS, CacheTypes.SEARCH);
+        }
+    }
+
+    public static void enable(CacheTypes... cacheTypes){
+        Arrays.stream(cacheTypes).forEach(ty -> {
+            if(ty.equals(CacheTypes.DEFAULT) && !enabled.get())
+                enabled.set(true);
+
+            if(ty.equals(CacheTypes.RANKINGS) && !rankings.get())
+                rankings.set(true);
+
+            if(ty.equals(CacheTypes.SEARCH) && !search.get())
+                search.set(true);
+        });
+    }
+
+    public static void disable(CacheTypes... cacheTypes){
+        Arrays.stream(cacheTypes).forEach(ty -> {
+            if(ty.equals(CacheTypes.DEFAULT) && enabled.get())
+                enabled.set(false);
+
+            if(ty.equals(CacheTypes.RANKINGS) && rankings.get())
+                rankings.set(false);
+
+            if(ty.equals(CacheTypes.SEARCH) && search.get())
+                search.set(false);
+        });
     }
 
 }

--- a/src/main/java/tk/mihou/amatsuki/impl/cache/entities/CacheEntity.java
+++ b/src/main/java/tk/mihou/amatsuki/impl/cache/entities/CacheEntity.java
@@ -2,9 +2,13 @@ package tk.mihou.amatsuki.impl.cache.entities;
 
 import tk.mihou.amatsuki.impl.cache.CacheManager;
 
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 public class CacheEntity<T> {
 
     private T entity;
+    private List<T> list;
     private final long expected;
     private final String key;
 
@@ -14,6 +18,18 @@ public class CacheEntity<T> {
         this.expected = System.currentTimeMillis() + CacheManager.unit.toMillis(CacheManager.lifespan.get());
     }
 
+    public CacheEntity(List<T> entity, String key){
+        this.list = entity;
+        this.key = key;
+        this.expected = System.currentTimeMillis() + CacheManager.unit.toMillis(CacheManager.lifespan.get());
+    }
+
+    public CacheEntity(List<T> entity, String key, int lifespan){
+        this.list = entity;
+        this.key = key;
+        this.expected = System.currentTimeMillis() + CacheManager.unit.toMillis(lifespan);
+    }
+
     /**
      * Retrieves the entity hiding inside the cache.
      * This only works when cache is enabled.
@@ -21,6 +37,10 @@ public class CacheEntity<T> {
      */
      public T get(){
          return entity;
+     }
+
+     public List<T> getList(){
+         return list;
      }
 
     /**
@@ -42,6 +62,12 @@ public class CacheEntity<T> {
      */
     public void replace(T entity){
         this.entity = entity;
+    }
+
+    public boolean isList(){
+        // We can only rely on this for now.
+        // If you have a better solution, please do a PR.
+        return list != null;
     }
 
     /**

--- a/src/main/java/tk/mihou/amatsuki/impl/cache/enums/CacheTypes.java
+++ b/src/main/java/tk/mihou/amatsuki/impl/cache/enums/CacheTypes.java
@@ -1,0 +1,7 @@
+package tk.mihou.amatsuki.impl.cache.enums;
+
+public enum CacheTypes {
+
+    RANKINGS, SEARCH, DEFAULT;
+
+}


### PR DESCRIPTION
Closes #2 
- [x] Implement caching for Trending (default lifespan: 6 hours).
- [x] Implement caching for Latest Series (default lifespan: 1-2 hours because it can change at any point of time).
- [x] Certain Rankings cache (default lifespan depends on the Rankings type).
- [x] Cache for searching of users and stories (default lifespan: 1-2 hours).
- [x] SearchFinder - default lifespan: (6 hours).
- [x] Add customizable referrer, default: https://manabot.fun/hello.html